### PR TITLE
added isset check to $query['v']

### DIFF
--- a/Masih/YoutubeDownloader/YoutubeDownloader.php
+++ b/Masih/YoutubeDownloader/YoutubeDownloader.php
@@ -246,7 +246,8 @@ class YoutubeDownloader
 			elseif (preg_match('/\/watch/i', $path, $temp) && isset($urlPart['query']))
 			{
 				$query = $this->decodeString($urlPart['query']);
-				$videoId = $query['v'];
+				if (isset($query['v']))
+					$videoId = $query['v'];
 			}
 		}
 


### PR DESCRIPTION
Removed warning for empty $query['v'], when only querying a Playlist without a videolink.